### PR TITLE
Rewrite Onboard without unstated or Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "concurrently": "^3.5.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^5.0.0",
-    "gulp-sass": "^4.0.1"
+    "gulp-sass": "^4.0.1",
+    "react-test-renderer": "^16.4.2"
   },
   "proxy": "http://localhost:8080"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Route, Switch } from "react-router-dom";
 import './css/styles.css';
+import Onboard from './onboard/Onboard';
 import OnboardSignUp from './onboard/OnboardSignUp';
 import OnboardSignIn from './onboard/OnboardSignIn';
 import OnboardSMTP from './onboard/OnboardSMTP';
@@ -8,41 +9,31 @@ import OnboardStorage from './onboard/OnboardStorage';
 import Home from './Home';
 import Header from './Header';
 
-var apiRoutes = {
-  signIn: '/signin',
-  signUp: '/signup',
-  smtp: '/smtp',
-  testEmail: '/test-email',
-  nextcloud: '/nextcloud',
-  uploadBooks: '/upload-books'
-}
+const SessionStatus = Object.freeze({
+  active: 'active',
+  none: 'none',
+  noAdmin: 'noAdmin',
+})
 
 class App extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      // this should be rendered by the server
+      sessionStatus: SessionStatus.noAdmin 
+    }
+  }
+
   render() {
     return (
       <div className="app">
         <div id="loader"><i></i></div>
-        <Header uploadBooksAPI={apiRoutes.uploadBooks} />
+        <Header uploadBooksAPI="/upload-books" />
         <div className="alert" id="alert"><i></i></div>
-        <Switch>
-          <Route
-            path="/signup"
-            render={(props) => <OnboardSignUp {...props} signUpAPI={apiRoutes.signUp} />}
-          />
-          <Route
-            path="/smtp"
-            render={(props) => <OnboardSMTP {...props} smtpAPI={apiRoutes.smtp} testEmailAPI={apiRoutes.testEmail} />}
-          />
-          <Route
-            path="/storage"
-            render={(props) => <OnboardStorage {...props} nextcloudAPI={apiRoutes.nextcloud} />}
-          />
-          <Route
-            path="/signin"
-            render={(props) => <OnboardSignIn {...props} signInAPI={apiRoutes.signIn} />}
-          />
-          <Route exact path='/' component={Home} />
-        </Switch>
+        { this.state.sessionStatus === SessionStatus.noAdmin 
+          ?  <Onboard /> : <Home /> 
+        }
       </div>
     );
   }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -425,7 +425,7 @@ table {
 .cursor-pointer, .button, .header__logo, .header__menu, .header__notification, .header__books, .header__link, .header__signup, .currently-reading__left, .currently-reading__right {
   cursor: pointer; }
 
-.none, #uploadBooks, .alert, .header__m-dropdown, .header__n-dropdown, .onboard__error, .onboard__sub-form i, .onboard__sub-form p, .onboard #nextcloudForm.none {
+.none, #uploadBooks, .alert, .header__m-dropdown, .header__n-dropdown, .onboard__sub-form i, .onboard__sub-form p, .onboard #nextcloudForm.none {
   display: none; }
 
 .block, .button, .header__m-dropdown.open, .open.header__n-dropdown, .onboard__label, .onboard__sub-label, .onboard__error--active, .onboard__submit, .onboard__sub-form i.show, .onboard__sub-form p.show {

--- a/src/onboard/AdminForm.js
+++ b/src/onboard/AdminForm.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export default props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick}>
+    <label className="onboard__label">Create an admin account</label>
+    <input type="text" 
+      name="username" 
+      placeholder="Username (johnwell)*" 
+      value={props.username}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.username}</div>
+    <input type="email" 
+      name="email"
+      placeholder="Email address (info@example.com)*" 
+      value={props.email}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.email}</div>
+    <input type="password" 
+      name="password"
+      placeholder="Password*" 
+      value={props.password}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.password}</div>
+    <input type="submit" 
+      className="button button--primary onboard__submit" 
+      value="Submit" />
+  </form>
+
+ 

--- a/src/onboard/Onboard.js
+++ b/src/onboard/Onboard.js
@@ -4,6 +4,9 @@ import {
   validateSMTPConfig, 
   validateStorageConfig } from './validation.js'
 import { hasNoErrors } from '../utils/validation.js'
+import AdminForm from './AdminForm.js'
+import SMTPForm from './SMTPForm.js'
+import StorageForm from './StorageForm.js'
 import * as api from './api.js'
 
 const Step = Object.freeze({ 
@@ -62,167 +65,6 @@ const defaultState = Object.freeze({
   storage: defaultNextcloudStorageConfig
 });
 
-const AdminForm = props => 
-  <form className="onboard" onSubmit={props.onSubmitButtonClick}>
-    <label className="onboard__label">Create an admin account</label>
-    <input type="text" 
-      name="username" 
-      placeholder="Username (johnwell)*" 
-      value={props.username}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.username}</div>
-    <input type="email" 
-      name="email"
-      placeholder="Email address (info@example.com)*" 
-      value={props.email}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.email}</div>
-    <input type="password" 
-      name="password"
-      placeholder="Password*" 
-      value={props.password}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.password}</div>
-    <input type="submit" 
-      className="button button--primary onboard__submit" 
-      value="Submit" />
-  </form>
-
-const TestEmailSubForm = props => 
-  <div className="onboard__sub-form">
-    <label className="onboard__label onboard__label--small">Send test email to</label>
-    <input type="email" 
-      name="testAddress"
-      placeholder="Email address" 
-      value={props.address}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.address}</div>
-    <div className="onboard__sub-submit">
-      <button className="button button--secondary" 
-        onClick={props.onSendTestEmailButtonClick}>Send</button>
-      <i id="smtpLoader"></i>
-      { props.testSuccess && <p>Test email sent successfully!</p> }
-    </div>
-  </div>
-
-const SMTPForm = props => 
-  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
-    <label className="onboard__label">Mail server configuration</label>
-    <input type="text" 
-      name="hostname"
-      value={props.hostname}
-      placeholder="SMTP hostname (smtp.fastmail.com)*" 
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.hostname}</div>
-    <input type="text" 
-      name="port"
-      placeholder="SMTP port (25/587/465)*" 
-      value={props.port}
-      onChange={props.onInputChange} />
-    <div className="onboard__error" >{props.errors.port}</div>
-    <input type="email" 
-      name="username"
-      placeholder="SMTP username (hello@johnwell.com)*" 
-      value={props.username}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.username}</div>
-    <input type="password" 
-      name="password"
-      placeholder="SMTP password*" 
-      value={props.password}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.password}</div>
-    <TestEmailSubForm {...props.testEmail} />
-    <div className="onboard__button-group">
-      <button className="button button--secondary" 
-        onClick={props.onSkipButtonClick}>Skip</button>
-      <input type="submit" 
-        className="button button--primary onboard__submit" 
-        value="Submit"/>
-    </div>
-  </form>
-
-const NextcloudSubForm = props => 
-  <div id="nextcloudForm">
-    <div className="onboard__label onboard__label--small">
-      Nextcloud OAuth2 configuration
-    </div>
-    <p className="onboard__sub-label">
-      Redirect URI: &lt;JOYREAD URL&gt;/nextcloud-auth/&lt;USER ID&gt;
-    </p>
-    <p className="onboard__sub-label">
-      Check <a href="">FAQ</a> on how to integrate Nextcloud.
-    </p>
-    <input type="text" 
-      name="url"
-      placeholder="Nextcloud URL (https://mynextcloud.com)*" 
-      value={props.url}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.url}</div>
-    <input type="text" 
-      name="clientID"
-      placeholder="Client id*" 
-      value={props.clientID}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.clientID}</div>
-    <input type="text" 
-      name="secret"
-      placeholder="Client secret*" 
-      value={props.secret}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.secret}</div>
-    <input type="text" 
-      name="directory"
-      placeholder="Nextcloud directory (/books or /)*" 
-      value={props.directory}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.directory}</div>
-    <input type="text" 
-      name="joyreadURL"
-      placeholder="Joyread URL (https://myjoyread.com)*" 
-      value={props.joyreadURL}
-      onChange={props.onInputChange} />
-    <div className="onboard__error">{props.errors.joyreadURL}</div>
-  </div>
-
-const StorageForm = props => 
-  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
-    <label className="onboard__label">Ebooks storage option</label>
-    <div className="onboard__note">NOTE: Please make sure you choose the correct option, the storage option cannot be changed again.</div>
-    <div className="onboard__radio-form">
-      <div>
-        <input type="radio" 
-          name="storage" 
-          id="nextcloudRadio" 
-          checked={props.type === "nextcloud"}
-          onChange={props.onStorageOptionChange}
-          value={"nextcloud"} />
-        <label htmlFor="nextcloudRadio">Nextcloud</label>
-      </div>
-      <p className="onboard__info">
-        Nextcloud as a storage option will provide you a way to sync ebooks...
-      </p>
-      <div>
-        <input type="radio" 
-          name="storage" 
-          id="localRadio" 
-          checked={props.type === "local"}
-          onChange={props.onStorageOptionChange}
-          value="local" />
-        <label htmlFor="localRadio">Local storage</label>
-      </div>
-      <p className="onboard__info">
-        Local storage as a storage option will provide you a way to sync ebooks...
-      </p>
-    </div>
-    { props.type === "nextcloud" && 
-        <NextcloudSubForm 
-          onInputChange={props.onNextcloudInputChange}
-          {...props} />
-    }
-    <input type="submit" className="button button--primary onboard__submit" value="Submit" />
-  </form>
-
 export default class OnboardContainer extends Component {
 
   constructor() {
@@ -243,10 +85,9 @@ export default class OnboardContainer extends Component {
   handleSMTPInputChange = ({ target }) => {
     const { name, value } = target;
     this.setState(prevState => {
-      const prevSmtp = prevState.smtp || defaultState.smtp;
       return {
         smtp: { 
-          ...prevSmtp,
+          ...prevState.smtp,
           [name]: value
         }
       }
@@ -256,11 +97,9 @@ export default class OnboardContainer extends Component {
   handleNextcloudInputChange = ({ target }) => {
     const { name, value } = target;
     this.setState(prevState => {
-      const prevStorage = prevState.storage 
-        || defaultNextcloudStorageConfig;
       return {
         storage: { 
-          ...prevStorage,
+          ...prevState.storage,
             [name]: value
           }
         }
@@ -333,7 +172,7 @@ export default class OnboardContainer extends Component {
       .then(res => {
         switch(res.status) {
           case 200: {
-            console.log('success!!')
+            this.props.onComplete(res.body)
             break;
           }
           case 400: {

--- a/src/onboard/Onboard.js
+++ b/src/onboard/Onboard.js
@@ -1,0 +1,332 @@
+import React, { Component } from 'react'
+
+const Step = Object.freeze({ 
+  createAdmin: 0,
+  setupSMTP: 1,
+  setupStorage: 2
+})
+
+const defaultState = Object.freeze({ 
+  step: Step.createAdmin, 
+  admin: {
+    username: "",
+    email: "",
+    password: "",
+    errors: {
+      username: "",
+      email: "",
+      password: ""
+    }
+  },
+  smtp: {
+    hostname: "",
+    port: "",
+    username: "",
+    password: "",
+    testAddress: "",
+    errors: {
+      hostname: "",
+      port: "",
+      username: "",
+      password: "",
+    testAddress: ""
+    }
+  },
+  storage: {
+    userID: null,
+    nextcloud: {
+      url: "",
+      clientID: "",
+      secret: "",
+      directory: "",
+      joyreadURL: "",
+      errors: {
+        url: "",
+        clientID: "",
+        secret: "",
+        directory: "",
+        joyreadURL: ""
+      }
+    }
+  }
+  
+});
+
+const AdminForm = props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick}>
+    <label className="onboard__label">Create an admin account</label>
+    <input type="text" 
+      name="username" 
+      placeholder="Username (johnwell)*" 
+      value={props.username}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.username}</div>
+    <input type="email" 
+      name="email"
+      placeholder="Email address (info@example.com)*" 
+      value={props.email}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.email}</div>
+    <input type="password" 
+      name="password"
+      placeholder="Password*" 
+      value={props.password}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.password}</div>
+    <input type="submit" 
+      className="button button--primary onboard__submit" 
+      value="Submit" />
+  </form>
+
+const SMTPForm = props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
+    <label className="onboard__label">Mail server configuration</label>
+    <input type="text" 
+      name="hostname"
+      value={props.hostname}
+      placeholder="SMTP hostname (smtp.fastmail.com)*" 
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.hostname}</div>
+    <input type="text" 
+      name="port"
+      placeholder="SMTP port (25/587/465)*" 
+      value={props.port}
+      onChange={props.onInputChange} />
+    <div className="onboard__error" >{props.errors.port}</div>
+    <input type="email" 
+      name="username"
+      placeholder="SMTP username (hello@johnwell.com)*" 
+      value={props.username}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.username}</div>
+    <input type="password" 
+      name="password"
+      placeholder="SMTP password*" 
+      value={props.password}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.password}</div>
+    <div className="onboard__sub-form">
+      <label className="onboard__label onboard__label--small">Send test email to</label>
+      <input type="email" 
+        name="testAddress"
+        placeholder="Email address" 
+        value={props.testAddress}
+        onChange={props.onInputChange} />
+      <div className="onboard__error">{props.errors.testAddress}</div>
+      <div className="onboard__sub-submit">
+        <button className="button button--secondary" 
+          onClick={props.onSendTestEmailButtonClick}>Send</button>
+        <i id="smtpLoader"></i>
+        { props.testSuccess && <p>Test email sent successfully!</p>}
+      </div>
+    </div>
+    <div className="onboard__button-group">
+      <button className="button button--secondary" 
+        onClick={props.onSkipButtonClick}>Skip</button>
+      <input type="submit" 
+        className="button button--primary onboard__submit" 
+        value="Submit"/>
+    </div>
+  </form>
+
+const NextcloudSubForm = props => 
+  <div id="nextcloudForm">
+    <div className="onboard__label onboard__label--small">
+      Nextcloud OAuth2 configuration
+    </div>
+    <p className="onboard__sub-label">
+      Redirect URI: &lt;JOYREAD URL&gt;/nextcloud-auth/{props.userID}
+    </p>
+    <p className="onboard__sub-label">
+      Check <a href="">FAQ</a> on how to integrate Nextcloud.
+    </p>
+    <input type="text" 
+      name="url"
+      placeholder="Nextcloud URL (https://mynextcloud.com)*" 
+      value={props.url}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.url}</div>
+    <input type="text" 
+      name="clientID"
+      placeholder="Client id*" 
+      value={props.clientID}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.clientID}</div>
+    <input type="text" 
+      name="secret"
+      placeholder="Client secret*" 
+      value={props.secret}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.secret}</div>
+    <input type="text" 
+      name="directory"
+      placeholder="Nextcloud directory (/books or /)*" 
+      value={props.directory}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.directory}</div>
+    <input type="text" 
+      name="joyreadURL"
+      placeholder="Joyread URL (https://myjoyread.com)*" 
+      value={props.joyreadURL}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.joyreadURL}</div>
+  </div>
+
+const StorageForm = props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
+    <label className="onboard__label">Ebooks storage option</label>
+    <div className="onboard__note">NOTE: Please make sure you choose the correct option, the storage option cannot be changed again.</div>
+    <div className="onboard__radio-form">
+      <div>
+        <input type="radio" 
+          name="storage" 
+          id="nextcloudRadio" 
+          checked={!!props.nextcloud}
+          onChange={props.onStorageOptionChange}
+          value={"nextcloud"} />
+        <label htmlFor="nextcloudRadio">Nextcloud</label>
+      </div>
+      <p className="onboard__info">
+        Nextcloud as a storage option will provide you a way to sync ebooks...
+      </p>
+      <div>
+        <input type="radio" 
+          name="storage" 
+          id="localRadio" 
+          checked={!props.nextcloud}
+          onChange={props.onStorageOptionChange}
+          value="local" />
+        <label htmlFor="localRadio">Local storage</label>
+      </div>
+      <p className="onboard__info">
+        Local storage as a storage option will provide you a way to sync ebooks...
+      </p>
+    </div>
+    { props.nextcloud && 
+        <NextcloudSubForm 
+          userID={props.userID} 
+          onInputChange={props.onNextcloudInputChange}
+          {...props.nextcloud} />
+    }
+    <input type="submit" className="button button--primary onboard__submit" value="Submit" />
+  </form>
+
+export default class OnboardContainer extends Component {
+
+  constructor() {
+    super();
+    this.state = defaultState;
+  }
+
+  handleAdminInputChange = ({ target }) => {
+    const { name, value } = target;
+    this.setState(prevState => ({
+      admin: { 
+        ...prevState.admin,
+        [name]: value
+      }
+    }));
+  }
+
+  handleSMTPInputChange = ({ target }) => {
+    console.log('input')
+    const { name, value } = target;
+    this.setState(prevState => {
+      const prevSmtp = prevState.smtp || defaultState.smtp;
+      return {
+        smtp: { 
+          ...prevSmtp,
+          [name]: value
+        }
+      }
+    });
+  }
+
+  handleNextcloudInputChange = ({ target }) => {
+    const { name, value } = target;
+    this.setState(prevState => {
+      const prevNextcloud = prevState.storage.nextcloud 
+        || defaultState.storage.nextcloud;
+      return {
+        storage: { 
+          ...prevState.storage,
+          nextcloud: {
+            ...prevNextcloud,
+            [name]: value
+          }
+        }
+      }
+    });
+  }
+
+  handleStorageOptionChange = e => {
+    if (e.target.value === "local")
+      this.setState(prevState => ({
+        storage: {
+          ...prevState.storage,
+          nextcloud: null
+        }
+      }));
+    else
+      this.setState(prevState => ({
+        storage: {
+          ...prevState.storage,
+          nextcloud: defaultState.storage.nextcloud
+        }
+      }));
+  }
+
+
+  skipSMTPConfigStep = () => 
+    this.setState({ smtp: null, step: Step.setupStorage });
+
+  commitStep = e => {
+    e.preventDefault();
+    switch (this.state.step) {
+      case Step.createAdmin: {
+        // here we should perform validation and send request 
+        // to server. 
+        this.setState({ step: Step.setupSMTP });
+        break;
+      }
+
+      case Step.setupSMTP: {
+        // here we should perform validation and send request 
+        // to server. 
+        this.setState({ step: Step.setupStorage });
+        break;
+      }
+
+      default: { //storage
+        // here we should perform validation and send request 
+        // to server and after that finish gracefully. 
+        console.log('all done!', this.state)
+        break;
+      }
+        
+    }
+  }
+
+  render() {
+    switch (this.state.step) {
+      case Step.createAdmin: 
+        return <AdminForm 
+          onInputChange={this.handleAdminInputChange} 
+          onSubmitButtonClick={this.commitStep}
+          {...this.state.admin} />;
+      case Step.setupSMTP: 
+        return <SMTPForm 
+          onInputChange={this.handleSMTPInputChange} 
+          onSubmitButtonClick={this.commitStep}
+          onSkipButtonClick={this.skipSMTPConfigStep}
+          {...this.state.smtp} />;
+      default: // storage
+        return <StorageForm 
+          onStorageOptionChange={this.handleStorageOptionChange}
+          onNextcloudInputChange={this.handleNextcloudInputChange} 
+          onSubmitButtonClick={this.commitStep} 
+          {...this.state.storage} />;
+    } 
+  }
+
+}

--- a/src/onboard/Onboard.test.js
+++ b/src/onboard/Onboard.test.js
@@ -1,0 +1,286 @@
+import React from 'react';
+import OnboardContainer from './Onboard.js';
+import TestRenderer from 'react-test-renderer';
+const api =  require('./api.js')
+
+const submitEvent = Object.freeze({preventDefault: () => {}})
+
+
+jest.mock('./api.js', () => ({
+  postOnboardData: jest.fn(),
+  __mockedData: 42
+}));
+
+jest.mock('./AdminForm.js', () => props => 
+  <div componentType="AdminForm" {...props} />
+);
+jest.mock('./SMTPForm.js', () => props =>
+  <div componentType="SMTPForm" {...props} />
+);
+jest.mock('./StorageForm.js', () => props =>
+  <div componentType="StorageForm" {...props} />
+);
+
+const submitAdminData = (props, data) => {
+  props.onInputChange({ 
+    target: { name: "username", value: data.username } 
+  })
+
+  props.onInputChange({ 
+    target: { name: "email", value: data.email } 
+  })
+
+  props.onInputChange({ 
+    target: { name: "password", value: data.password } 
+  })
+
+  props.onSubmitButtonClick(submitEvent)
+}
+
+const submitSMTPData = (props, data) => {
+  props.onInputChange({ 
+    target: { name: "hostname", value: data.hostname } 
+  })
+
+  props.onInputChange({ 
+    target: { name: "port", value: data.port } 
+  })
+
+  props.onInputChange({ 
+    target: { name: "username", value: data.username } 
+  })
+
+  props.onInputChange({ 
+    target: { name: "password", value: data.password } 
+  })
+  props.onSubmitButtonClick(submitEvent)
+}
+
+const submitNexcloudData = (props, data) => {
+  props.onStorageOptionChange({ 
+    target: { name: "storage", value: "nextcloud"  }
+  })
+
+  props.onNextcloudInputChange({ 
+    target: { name: "url", value: data.url } 
+  })
+
+  props.onNextcloudInputChange({ 
+    target: { name: "clientID", value: data.clientID } 
+  })
+
+  props.onNextcloudInputChange({ 
+    target: { name: "secret", value: data.secret } 
+  })
+
+  props.onNextcloudInputChange({ 
+    target: { name: "directory", value: data.directory } 
+  })
+
+  props.onNextcloudInputChange({ 
+    target: { name: "joyreadURL", value: data.joyreadURL } 
+  })
+  props.onSubmitButtonClick(submitEvent)
+}
+
+describe('Minimal onboard process (No SMTP, Local Storage)', () => {
+  describe('successful scenario', () => {
+    let trees = [];
+    const onOnboardComplete = jest.fn()
+    
+
+    beforeAll(() => {
+      api.postOnboardData.mockReturnValueOnce(Promise.resolve({
+        status: 200,
+        body: "OK"
+      }))
+
+      const testRenderer = TestRenderer.create(
+        <OnboardContainer onComplete={onOnboardComplete}/>
+      );
+      const initialTree = testRenderer.toJSON();
+      trees.push(initialTree);
+
+      submitAdminData(initialTree.props, {
+        username: "tester",
+        email: "tester@gmail.com",
+        password: "secretpass"
+      })
+
+      const secondTree = testRenderer.toJSON();
+      trees.push(secondTree);
+
+      secondTree.props.onSkipButtonClick(submitEvent)
+
+      const thirdTree = testRenderer.toJSON();
+      trees.push(thirdTree);
+
+      thirdTree.props.onStorageOptionChange({ target: { value: "local" } })
+      thirdTree.props.onSubmitButtonClick(submitEvent)
+    })
+
+    it('starts with an AdminForm', () => {
+      const [ initialTree ] = trees;
+
+      expect(initialTree.props.componentType).toBe("AdminForm")
+    })
+
+    it('After submitting valid admin data, renders a SMTPForm', () => {
+      const [ , secondTree ] = trees;
+
+      expect(secondTree.props.componentType).toBe("SMTPForm")
+    })
+
+    it('After skipping SMTP config, renders a StorageForm', () => {
+      const [ , ,thirdTree ] = trees;
+
+      expect(thirdTree.props.componentType).toBe("StorageForm")
+    })
+
+    it('After submitting everything, should trigger the onSuccess callback', () => {
+      expect(onOnboardComplete).toHaveBeenCalledWith("OK")
+    })
+
+  })
+
+  describe('failiure scenario', () => {
+    it('blocks the SMTP form if Admin data is not input correctly', () => {
+      const testRenderer = TestRenderer.create(
+        <OnboardContainer onComplete={jest.fn()}/>
+      );
+      const initialTree = testRenderer.toJSON();
+
+      submitAdminData(initialTree.props, {
+        username: "tester",
+        email: "",
+        password: "secretpass"
+      });
+
+      const failiureTree = testRenderer.toJSON();
+      expect(failiureTree.props.componentType).toBe("AdminForm");
+      expect(failiureTree.props.errors.email).not.toHaveLength(0)
+    })
+  })
+})
+
+describe('largest onboard process (SMTP, Nextcloud)', () => {
+  describe('successful scenario', () => {
+    let trees = [];
+    const onOnboardComplete = jest.fn()
+    
+
+    beforeAll(() => {
+      api.postOnboardData.mockReturnValueOnce(Promise.resolve({
+        status: 200,
+        body: "OK"
+      }))
+
+      const testRenderer = TestRenderer.create(
+        <OnboardContainer onComplete={onOnboardComplete}/>
+      );
+      const initialTree = testRenderer.toJSON();
+      trees.push(initialTree);
+
+      submitAdminData(initialTree.props, {
+        username: "tester",
+        email: "tester@gmail.com",
+        password: "secretpass"
+      })
+
+      const secondTree = testRenderer.toJSON();
+      trees.push(secondTree);
+
+      submitSMTPData(secondTree.props, {
+        hostname: "mydomain.com",
+        username: "noreply",
+        port: "25",
+        password: "secretpass"
+      });
+
+      const thirdTree = testRenderer.toJSON();
+      trees.push(thirdTree);
+
+      submitNexcloudData(thirdTree.props, {
+        url: "mynextcloud.com",
+        clientID: "myid",
+        secret: "mysecret",
+        directory: "/ebooks",
+        joyreadURL: "myjoyread.com",
+      });
+    })
+
+    it('starts with an AdminForm', () => {
+      const [ initialTree ] = trees;
+
+      expect(initialTree.props.componentType).toBe("AdminForm")
+    })
+
+    it('After submitting valid admin data, renders a SMTPForm', () => {
+      const [ , secondTree ] = trees;
+
+      expect(secondTree.props.componentType).toBe("SMTPForm")
+    })
+
+    it('After submitting valid SMTP config, renders a StorageForm', () => {
+      const [ , ,thirdTree ] = trees;
+
+      expect(thirdTree.props.componentType).toBe("StorageForm")
+    })
+
+    it('After submitting everything, should trigger the onSuccess callback', () => {
+      expect(onOnboardComplete).toHaveBeenCalledWith("OK")
+    })
+  })
+
+  describe('failiure scenario', () => {
+    it('blocks the storage form if SMTP data is not input correctly', () => {
+      const testRenderer = TestRenderer.create(
+        <OnboardContainer onComplete={jest.fn()}/>
+      );
+      const initialTree = testRenderer.toJSON();
+
+      submitAdminData(initialTree.props, {
+        username: "tester",
+        email: "tester@gmail.com",
+        password: "secretpass"
+      });
+      submitSMTPData(testRenderer.toJSON().props, {
+        hostname: "mydomain.com",
+        username: "noreply",
+        port: "",
+        password: "secretpass"
+      });
+
+      const failiureTree = testRenderer.toJSON();
+      expect(failiureTree.props.componentType).toBe("SMTPForm");
+      expect(failiureTree.props.errors.port).not.toHaveLength(0)
+    })
+
+    it('does not trigger onComplete callback if storage data is not input correctly', () => {
+      const onCompleteCallback = jest.fn();
+      const testRenderer = TestRenderer.create(
+        <OnboardContainer onComplete={onCompleteCallback}/>
+      );
+      const initialTree = testRenderer.toJSON();
+
+      submitAdminData(initialTree.props, {
+        username: "tester",
+        email: "tester@gmail.com",
+        password: "secretpass"
+      });
+      submitSMTPData(testRenderer.toJSON().props, {
+        hostname: "mydomain.com",
+        username: "noreply",
+        port: "25",
+        password: "secretpass"
+      });
+      submitNexcloudData(testRenderer.toJSON().props, {
+        url: "mynextcloud.com",
+        clientID: "myid",
+        secret: "",
+        directory: "/ebooks",
+        joyreadURL: "myjoyread.com",
+      });
+    })
+  })
+})

--- a/src/onboard/SMTPForm.js
+++ b/src/onboard/SMTPForm.js
@@ -1,0 +1,57 @@
+import React from 'react'
+
+const TestEmailSubForm = props => 
+  <div className="onboard__sub-form">
+    <label className="onboard__label onboard__label--small">Send test email to</label>
+    <input type="email" 
+      name="testAddress"
+      placeholder="Email address" 
+      value={props.address}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.address}</div>
+    <div className="onboard__sub-submit">
+      <button className="button button--secondary" 
+        onClick={props.onSendTestEmailButtonClick}>Send</button>
+      <i id="smtpLoader"></i>
+      { props.testSuccess && <p>Test email sent successfully!</p> }
+    </div>
+  </div>
+
+export default props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
+    <label className="onboard__label">Mail server configuration</label>
+    <input type="text" 
+      name="hostname"
+      value={props.hostname}
+      placeholder="SMTP hostname (smtp.fastmail.com)*" 
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.hostname}</div>
+    <input type="text" 
+      name="port"
+      placeholder="SMTP port (25/587/465)*" 
+      value={props.port}
+      onChange={props.onInputChange} />
+    <div className="onboard__error" >{props.errors.port}</div>
+    <input type="email" 
+      name="username"
+      placeholder="SMTP username (hello@johnwell.com)*" 
+      value={props.username}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.username}</div>
+    <input type="password" 
+      name="password"
+      placeholder="SMTP password*" 
+      value={props.password}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.password}</div>
+    <TestEmailSubForm {...props.testEmail} />
+    <div className="onboard__button-group">
+      <button className="button button--secondary" 
+        onClick={props.onSkipButtonClick}>Skip</button>
+      <input type="submit" 
+        className="button button--primary onboard__submit" 
+        value="Submit"/>
+    </div>
+  </form>
+
+

--- a/src/onboard/StorageForm.js
+++ b/src/onboard/StorageForm.js
@@ -1,0 +1,84 @@
+import React from 'react'
+
+const NextcloudSubForm = props => 
+  <div id="nextcloudForm">
+    <div className="onboard__label onboard__label--small">
+      Nextcloud OAuth2 configuration
+    </div>
+    <p className="onboard__sub-label">
+      Redirect URI: &lt;JOYREAD URL&gt;/nextcloud-auth/&lt;USER ID&gt;
+    </p>
+    <p className="onboard__sub-label">
+      Check <a href="">FAQ</a> on how to integrate Nextcloud.
+    </p>
+    <input type="text" 
+      name="url"
+      placeholder="Nextcloud URL (https://mynextcloud.com)*" 
+      value={props.url}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.url}</div>
+    <input type="text" 
+      name="clientID"
+      placeholder="Client id*" 
+      value={props.clientID}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.clientID}</div>
+    <input type="text" 
+      name="secret"
+      placeholder="Client secret*" 
+      value={props.secret}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.secret}</div>
+    <input type="text" 
+      name="directory"
+      placeholder="Nextcloud directory (/books or /)*" 
+      value={props.directory}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.directory}</div>
+    <input type="text" 
+      name="joyreadURL"
+      placeholder="Joyread URL (https://myjoyread.com)*" 
+      value={props.joyreadURL}
+      onChange={props.onInputChange} />
+    <div className="onboard__error">{props.errors.joyreadURL}</div>
+  </div>
+
+export default props => 
+  <form className="onboard" onSubmit={props.onSubmitButtonClick} >
+    <label className="onboard__label">Ebooks storage option</label>
+    <div className="onboard__note">NOTE: Please make sure you choose the correct option, the storage option cannot be changed again.</div>
+    <div className="onboard__radio-form">
+      <div>
+        <input type="radio" 
+          name="storage" 
+          id="nextcloudRadio" 
+          checked={props.type === "nextcloud"}
+          onChange={props.onStorageOptionChange}
+          value={"nextcloud"} />
+        <label htmlFor="nextcloudRadio">Nextcloud</label>
+      </div>
+      <p className="onboard__info">
+        Nextcloud as a storage option will provide you a way to sync ebooks...
+      </p>
+      <div>
+        <input type="radio" 
+          name="storage" 
+          id="localRadio" 
+          checked={props.type === "local"}
+          onChange={props.onStorageOptionChange}
+          value="local" />
+        <label htmlFor="localRadio">Local storage</label>
+      </div>
+      <p className="onboard__info">
+        Local storage as a storage option will provide you a way to sync ebooks...
+      </p>
+    </div>
+    { props.type === "nextcloud" && 
+        <NextcloudSubForm 
+          onInputChange={props.onNextcloudInputChange}
+          {...props} />
+    }
+    <input type="submit" className="button button--primary onboard__submit" value="Submit" />
+  </form>
+
+

--- a/src/onboard/api.js
+++ b/src/onboard/api.js
@@ -1,0 +1,9 @@
+export const postOnboardData = data =>
+  fetch('/onboard', {
+    method: 'POST',
+    headers: {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+

--- a/src/onboard/validation.js
+++ b/src/onboard/validation.js
@@ -1,0 +1,102 @@
+const validateJoyreadUsername = username => {
+  if (username.length === 0)
+    return "username is required"
+  // we can add here more conditions for rejecting usernames like
+  // max length, allowed chars etc
+  return ""
+}
+
+const validateEmailAddress = email => {
+  if (email.length === 0)
+    return "e-mail is required"
+  return ""
+}
+
+const validatePassword = password => {
+  if (password.length === 0)
+    return "password is required"
+  return ""
+}
+
+const validateHostname = hostname => {
+  if (hostname.length === 0)
+    return "hostname is required"
+  return ""
+}
+
+const validateSMTPUsername = username => {
+  if (username.length === 0)
+    return "username is required"
+  return ""
+}
+
+const validatePort = port => {
+  console.log('validate port', port, port.length)
+  if (port.length === 0)
+    return {  value: port, error: "Port is required" };
+
+  const parsedPort = parseInt(port, 10)
+  if (isNaN(parsedPort) || parsedPort === 0)
+    return { value: port, error: "Invalid port" }
+
+  return { value: parsedPort, error: "" }
+}
+
+const validateURL = (url, config) => {
+  if (url.length === 0)
+    return `${config.name} URL is required`
+  return ""
+}
+
+const validateClientID = clientID => {
+  if (clientID.length === 0)
+    return "Client id is required"
+  return ""
+}
+
+const validateNextcloudSecret = secret => {
+  if (secret.length === 0)
+    return "secret is required"
+  return ""
+}
+
+const validateDirectory = directory => {
+  if (directory.length === 0)
+    return "directory is required"
+  return ""
+}
+
+export const validateAdminAccount = admin => {
+  const username = validateJoyreadUsername(admin.username);
+  const email = validateEmailAddress(admin.email);
+  const password = validateEmailAddress(admin.password);
+
+  const errors = { username, email, password }
+  return { ...admin, errors }
+}
+
+export const validateSMTPConfig = smtp => {
+  const hostname = validateHostname(smtp.hostname)
+  const username = validateSMTPUsername(smtp.username)
+  const { value: newPort, error: portError } = validatePort(smtp.port)
+  const password = validatePassword(smtp.password)
+
+  const errors = { hostname, username, port: portError, password }
+  return { ...smtp, port: newPort, errors }
+} 
+
+export const validateStorageConfig = storage => {
+  if (storage.type === "local")
+    return storage;
+
+  // assume nextcloud config
+  const url = validateURL(storage.url, { name: "Nextcloud" });
+  const clientID = validateClientID(storage.clientID);
+  const secret = validateNextcloudSecret(storage.secret);
+  const directory = validateDirectory(storage.directory);
+  const joyreadURL = validateURL(storage.joyreadURL, { name: "Joyread" });
+
+  const errors = { url, clientID, secret, directory, joyreadURL }
+  return { ...storage, type: "nextcloud", errors }
+}
+

--- a/src/onboard/validation.js
+++ b/src/onboard/validation.js
@@ -31,7 +31,6 @@ const validateSMTPUsername = username => {
 }
 
 const validatePort = port => {
-  console.log('validate port', port, port.length)
   if (port.length === 0)
     return {  value: port, error: "Port is required" };
 
@@ -82,12 +81,12 @@ export const validateSMTPConfig = smtp => {
   const password = validatePassword(smtp.password)
 
   const errors = { hostname, username, port: portError, password }
-  return { ...smtp, port: newPort, errors }
+  return { ...smtp, required: true, port: newPort, errors }
 } 
 
 export const validateStorageConfig = storage => {
   if (storage.type === "local")
-    return storage;
+    return { type: "local", errors: {} };
 
   // assume nextcloud config
   const url = validateURL(storage.url, { name: "Nextcloud" });

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,2 @@
+export const hasNoErrors = errors => 
+  Object.keys(errors).every(errorKey => errors[errorKey].length === 0)


### PR DESCRIPTION
Keep session state (is logged in?) in App component.
Create new stateful component Onboard which keeps track of the onboard
steps and input data and renders the correct form at each step.

I removed unstated and react-router because they were unnecessarily complex. You do't need routes for sign up, If you add them you will have to sprinkle redirects all over your code. I don't like unstated because updating multiple stores from any component can become a mess very quickly.

I still need to add validations on the forms and http requests. 